### PR TITLE
Add DS1307 RTC support

### DIFF
--- a/src/ESP32RET.ino
+++ b/src/ESP32RET.ino
@@ -35,6 +35,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "gvret_comm.h"
 #include "can_manager.h"
 #include "lawicel.h"
+#include "rtc_ds1307.h"
 
 byte i = 0;
 
@@ -158,6 +159,8 @@ void setup()
 
     Serial.begin(115200); //for production
     //Serial.begin(115200); //for testing
+
+    rtc.begin();
 
     pinMode(MOSFET_PIN, OUTPUT);
     digitalWrite(MOSFET_PIN, LOW);  // Inicia com Raspberry desligada
@@ -358,8 +361,9 @@ void adc_task(void *pvParameters) {
                 if (isPressed) { // Botão foi solto
                     uint32_t pressDuration = micros() - pressStartTime;
                     if (pressDuration <= 750000 && ultimoValorADC > 2450) { // Toque rápido
-                        char buffer[32];
-                        snprintf(buffer, sizeof(buffer), "ADC Click: %d\n", ultimoValorADC);
+                        char buffer[64];
+                        String now = rtc.nowString();
+                        snprintf(buffer, sizeof(buffer), "%s - ADC Click: %d\n", now.c_str(), ultimoValorADC);
                         Serial.write(buffer);
                     }
                     isPressed = false;
@@ -375,8 +379,9 @@ void adc_task(void *pvParameters) {
                     uint32_t pressDuration = micros() - pressStartTime;
                     if (pressDuration > 750000) { // 500ms = pressão mantida
                         if (micros() - lastHoldSent >= HOLD_INTERVAL) { // Envia a cada 500ms
-                            char buffer[32];
-                            snprintf(buffer, sizeof(buffer), "ADC Hold: %d\n", valorADC);
+                            char buffer[64];
+                            String now = rtc.nowString();
+                            snprintf(buffer, sizeof(buffer), "%s - ADC Hold: %d\n", now.c_str(), valorADC);
                             Serial.write(buffer);
                             lastHoldSent = micros();
                             ultimoValorADC = valorADC;
@@ -387,8 +392,9 @@ void adc_task(void *pvParameters) {
                 if (isPressed) { // Botão foi solto
                     uint32_t pressDuration = micros() - pressStartTime;
                     if (pressDuration <= 750000 && valorADC > 2450) { // Toque rápido
-                        char buffer[32];
-                        snprintf(buffer, sizeof(buffer), "ADC Click: %d\n", valorADC);
+                        char buffer[64];
+                        String now = rtc.nowString();
+                        snprintf(buffer, sizeof(buffer), "%s - ADC Click: %d\n", now.c_str(), valorADC);
                         Serial.write(buffer);
                     }
                     isPressed = false;

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "sys_io.h"
 #include "EEPROM.h"
+#include "rtc_ds1307.h"
 
 Logger::LogLevel Logger::logLevel = Logger::Info;
 uint32_t Logger::lastLogTime = 0;
@@ -169,7 +170,7 @@ boolean Logger::isDebug()
 void Logger::log(LogLevel level, const char *format, va_list args)
 {
     lastLogTime = millis();
-    Serial.print(lastLogTime);
+    Serial.print(rtc.nowString());
     Serial.print(" - ");
 
     switch (level) {

--- a/src/README.md
+++ b/src/README.md
@@ -16,6 +16,7 @@ I changed the code to accommodate the [MrDIY CAN shield](https://store.mrdiy.ca/
      - use connect pins for the CAN transceiver
      - make use for the shiled 2 LEDs
      - changes AP name (CAN Wireless) and password (mrdiy.ca)
+     - added DS1307 RTC support with time configuration via serial
 
 
 This code can be flashed directly using a browser [here](https://mrdiyca.gitlab.io/mrdiy-esp-online-flasher/):

--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -35,6 +35,7 @@
 #include "config.h"
 #include "sys_io.h"
 #include "lawicel.h"
+#include "rtc_ds1307.h"
 
 extern void CANHandler();
 
@@ -372,6 +373,24 @@ void SerialConsole::handleConfigCmd()
         Logger::console("Setting BRILHO to %i", newValue);
     } else if (cmdString == String("DESLIGAR")) {
         Logger::console("Setting DESLIGAR to %s", newString);
+    } else if (cmdString == String("SETTIME")) {
+        DateTime dt;
+        int vals[6];
+        if (sscanf(newString, "%d-%d-%dT%d:%d:%d", &vals[0], &vals[1], &vals[2], &vals[3], &vals[4], &vals[5]) == 6) {
+            dt.year = vals[0];
+            dt.month = vals[1];
+            dt.day = vals[2];
+            dt.hour = vals[3];
+            dt.minute = vals[4];
+            dt.second = vals[5];
+            if (rtc.write(dt)) {
+                Logger::console("RTC updated to %s", newString);
+            } else {
+                Logger::console("Failed to update RTC");
+            }
+        } else {
+            Logger::console("Format: YYYY-MM-DDTHH:MM:SS");
+        }
     } else if (cmdString == String("SYSTYPE")) {
         if (newValue < 0) newValue = 0;
         if (newValue > 2) newValue = 2;

--- a/src/rtc_ds1307.cpp
+++ b/src/rtc_ds1307.cpp
@@ -1,0 +1,60 @@
+#include "rtc_ds1307.h"
+
+static uint8_t bcd2bin(uint8_t val) {
+    return val - 6 * (val >> 4);
+}
+
+static uint8_t bin2bcd(uint8_t val) {
+    return val + 6 * (val / 10);
+}
+
+bool RTC_DS1307::begin() {
+    Wire.begin();
+    return true;
+}
+
+bool RTC_DS1307::read(DateTime &dt) {
+    Wire.beginTransmission(0x68);
+    Wire.write(0);
+    if (Wire.endTransmission() != 0) return false;
+    if (Wire.requestFrom(0x68, 7) != 7) return false;
+    dt.second = bcd2bin(Wire.read() & 0x7F);
+    dt.minute = bcd2bin(Wire.read());
+    dt.hour = bcd2bin(Wire.read());
+    Wire.read(); // skip day of week
+    dt.day = bcd2bin(Wire.read());
+    dt.month = bcd2bin(Wire.read());
+    dt.year = bcd2bin(Wire.read()) + 2000;
+    return true;
+}
+
+bool RTC_DS1307::write(const DateTime &dt) {
+    Wire.beginTransmission(0x68);
+    Wire.write(0);
+    Wire.write(bin2bcd(dt.second));
+    Wire.write(bin2bcd(dt.minute));
+    Wire.write(bin2bcd(dt.hour));
+    Wire.write(1); // day of week dummy
+    Wire.write(bin2bcd(dt.day));
+    Wire.write(bin2bcd(dt.month));
+    Wire.write(bin2bcd(dt.year - 2000));
+    return Wire.endTransmission() == 0;
+}
+
+String RTC_DS1307::format(const DateTime &dt) {
+    char buf[20];
+    sprintf(buf, "%04d-%02d-%02d %02d:%02d:%02d",
+            dt.year, dt.month, dt.day,
+            dt.hour, dt.minute, dt.second);
+    return String(buf);
+}
+
+String RTC_DS1307::nowString() {
+    DateTime dt;
+    if (read(dt)) {
+        return format(dt);
+    }
+    return String("0000-00-00 00:00:00");
+}
+
+RTC_DS1307 rtc;

--- a/src/rtc_ds1307.h
+++ b/src/rtc_ds1307.h
@@ -1,0 +1,27 @@
+#ifndef RTC_DS1307_H
+#define RTC_DS1307_H
+
+#include <Arduino.h>
+#include <Wire.h>
+
+struct DateTime {
+    uint16_t year;
+    uint8_t month;
+    uint8_t day;
+    uint8_t hour;
+    uint8_t minute;
+    uint8_t second;
+};
+
+class RTC_DS1307 {
+public:
+    bool begin();
+    bool read(DateTime &dt);
+    bool write(const DateTime &dt);
+    String format(const DateTime &dt);
+    String nowString();
+};
+
+extern RTC_DS1307 rtc;
+
+#endif // RTC_DS1307_H


### PR DESCRIPTION
## Summary
- add simple DS1307 driver
- initialize RTC and timestamp log and ADC messages
- allow setting time via new `SETTIME` command
- document RTC feature in README

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887597a83cc8325ab516920647593dc