### PR TITLE
Fix DS1307 hour masking

### DIFF
--- a/src/rtc_ds1307.cpp
+++ b/src/rtc_ds1307.cpp
@@ -20,7 +20,7 @@ bool RTC_DS1307::read(DateTime &dt) {
     if (Wire.requestFrom(0x68, 7) != 7) return false;
     dt.second = bcd2bin(Wire.read() & 0x7F);
     dt.minute = bcd2bin(Wire.read());
-    dt.hour = bcd2bin(Wire.read());
+    dt.hour = bcd2bin(Wire.read() & 0x3F);
     Wire.read(); // skip day of week
     dt.day = bcd2bin(Wire.read());
     dt.month = bcd2bin(Wire.read());


### PR DESCRIPTION
## Summary
- mask the hour byte when reading from DS1307

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68877cda57588325a9dd2f1ed2d1a12e