### PR TITLE
Fix sleep wakeup in CAN manager

### DIFF
--- a/src/can_manager.cpp
+++ b/src/can_manager.cpp
@@ -294,6 +294,8 @@ void CANManager::loop()
                 sleeping = true;
                 esp_sleep_enable_ext0_wakeup((gpio_num_t)CAN_INT_PIN, 1); // Acorda com atividade no CAN
                 esp_light_sleep_start(); // ESP32 dorme
+                sleeping = false; // volta a processar apos acordar
+                Serial.println("Woke from sleep");
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure the ESP32 exits sleep mode correctly

## Testing
- `platformio test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a79378ee4832586e37f18064df751