### PR TITLE
Evita despertar pela serial no modo sleep

### DIFF
--- a/src/can_manager.cpp
+++ b/src/can_manager.cpp
@@ -6,6 +6,7 @@
 #include "gvret_comm.h"
 #include "lawicel.h"
 #include "ELM327_Emulator.h"
+#include "esp_sleep.h"
 
 unsigned long lastCANActivity = 0;
 extern unsigned long lastSerialActivity;
@@ -292,6 +293,7 @@ void CANManager::loop()
 
                 Serial.println("Entering sleep mode...");
                 sleeping = true;
+                esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_UART); // Evita acordar pela serial
                 esp_sleep_enable_ext0_wakeup((gpio_num_t)CAN_INT_PIN, 1); // Acorda com atividade no CAN
                 esp_light_sleep_start(); // ESP32 dorme
                 sleeping = false; // volta a processar apos acordar


### PR DESCRIPTION
## Summary
- garante que apenas o barramento CAN acorde o ESP32
- inclui cabecalho `esp_sleep.h` e desabilita wakeup pela UART antes do sleep

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b19488354c8325b3349ee3f52de317