### PR TITLE
Use bounded string operations

### DIFF
--- a/src/ESP32RET.ino
+++ b/src/ESP32RET.ino
@@ -119,7 +119,8 @@ void loadSettings()
     if (nvPrefs.getString("SSID", settings.SSID, 32) == 0)
     {
         //strcpy(settings.SSID, deviceName);
-        strcat(settings.SSID, "Sabidos");
+        strncpy(settings.SSID, "Sabidos", sizeof(settings.SSID) - 1);
+        settings.SSID[sizeof(settings.SSID) - 1] = '\0';
    }
 
     if (nvPrefs.getString("wpa2Key", settings.WPA2Key, 64) == 0)
@@ -128,8 +129,9 @@ void loadSettings()
     }
     if (nvPrefs.getString("btname", settings.btName, 32) == 0)
     {
-        strcpy(settings.btName, "ELM327-");
-        strcat(settings.btName, deviceName);
+        strncpy(settings.btName, "ELM327-", sizeof(settings.btName) - 1);
+        settings.btName[sizeof(settings.btName) - 1] = '\0';
+        strncat(settings.btName, deviceName, sizeof(settings.btName) - strlen(settings.btName) - 1);
     }
 
     char buff[80];

--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -363,15 +363,18 @@ void SerialConsole::handleConfigCmd()
         writeEEPROM = true;
     } else if (cmdString == String("BTNAME")) {
         Logger::console("Setting Bluetooth Name to %s", newString);
-        strcpy((char *)settings.btName, newString);
+        strncpy((char *)settings.btName, newString, sizeof(settings.btName) - 1);
+        settings.btName[sizeof(settings.btName) - 1] = '\0';
         writeEEPROM = true;
     } else if (cmdString == String("SSID")) {
         Logger::console("Setting SSID to %s", newString);
-        strcpy((char *)settings.SSID, newString);
+        strncpy((char *)settings.SSID, newString, sizeof(settings.SSID) - 1);
+        settings.SSID[sizeof(settings.SSID) - 1] = '\0';
         writeEEPROM = true;
     } else if (cmdString == String("WPA2KEY")) {
         Logger::console("Setting WPA2 Key to %s", newString);
-        strcpy((char *)settings.WPA2Key, newString);
+        strncpy((char *)settings.WPA2Key, newString, sizeof(settings.WPA2Key) - 1);
+        settings.WPA2Key[sizeof(settings.WPA2Key) - 1] = '\0';
         writeEEPROM = true;
     } else if (cmdString == String("BRILHO")) {
         Logger::console("Setting BRILHO to %i", newValue);


### PR DESCRIPTION
## Summary
- guard credential and name fields against overflow by using strncpy and strncat

## Testing
- `pio run` *(fails: HTTPClientError while installing espressif32 @ 5.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a37050ec83259128529b63885c08